### PR TITLE
Fixes remove followingUsers bug

### DIFF
--- a/P20-Friend-Search/content.md
+++ b/P20-Friend-Search/content.md
@@ -447,6 +447,7 @@ The biggest novelty in the `FriendSearchViewController` is the concept of a loca
           ParseHelper.removeFollowRelationshipFromUser(PFUser.currentUser()!, toUser: user)
           // update local cache
           removeObject(user, fromArray: &followingUsers)
+          self.followingUsers = followingUsers
         }
       }
 >


### PR DESCRIPTION
Resolves bug where the `if var` binding creates a copy of the original value inside the optional enum, thus old code did not remove users when `removeObject` was used.
